### PR TITLE
비효율적인 객체 기본 값 제거

### DIFF
--- a/src/train_lstm.py
+++ b/src/train_lstm.py
@@ -18,7 +18,7 @@ class SeqDS(Dataset):
     def __getitem__(self, i): return self.X[i], self.Y[i]
 
 class LSTMReg(nn.Module):
-    def __init__(self, in_dim, hidden=64, layers=1, out_dim=3, dropout=0.4):
+    def __init__(self, in_dim, hidden, layers, out_dim=3, dropout=0.4):
         super().__init__()
         self.lstm = nn.LSTM(in_dim, hidden, num_layers=layers, batch_first=True, dropout=dropout)
         self.head = nn.Sequential(nn.Linear(hidden, 128), nn.ReLU(), nn.Linear(128, out_dim))


### PR DESCRIPTION
argument 받을 때 이미 default 값이 있으니 모델 __init__ 에서 hidden과 layers는 기본 값이 필요 없음